### PR TITLE
 Fix a crash when repository uses custom flake8 format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ before_script:
   - ./cc-test-reporter before-build
 
 before_install:
- - pyenv global 3.5.3
- - pip install flake8
+  - pyenv global 3.6.3
+  - pip install flake8
 
 language: ruby
 rvm:
- - 2.4
- 
+  - 2.4
+
 after_script:
- - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/lib/pronto/flake8.rb
+++ b/lib/pronto/flake8.rb
@@ -64,7 +64,7 @@ module Pronto
         python_files = filter_python_files(files)
         file_paths_str = python_files.join(' ')
         if !file_paths_str.empty?
-          parse_output `#{flake8_executable} #{file_paths_str}`
+          parse_output `#{flake8_executable} --format=default #{file_paths_str}`
         else
           []
         end
@@ -73,7 +73,7 @@ module Pronto
 
     def filter_python_files(all_files)
       all_files.select { |file_path| file_path.to_s.end_with? PYTHON_FILE_EXTENSION}
-               .map { |py_file| py_file.to_s.shellescape } 
+               .map { |py_file| py_file.to_s.shellescape }
     end
 
     def parse_output(executable_output)

--- a/spec/pronto/flake8_spec.rb
+++ b/spec/pronto/flake8_spec.rb
@@ -35,6 +35,7 @@ module Pronto
         exp = flake8.filter_python_files(files)
         expect(exp).to eq(['/Users/rabraham/file.py'])
       end
+
       it 'extracts violation level' do
         expect(flake8.violation_level('W391 message2')).to eq('warning')
         expect(flake8.violation_level('E391 message2')).to eq('error')
@@ -91,6 +92,7 @@ module Pronto
           expect(flake8.run).to eql([])
         end
       end
+
       context 'with patch data' do
         before(:each) do
           function_use = <<-HEREDOC
@@ -98,6 +100,7 @@ module Pronto
           add_to_index('content.py', function_use)
           create_commit
         end
+
         context 'with error in changed file' do
           before(:each) do
             create_branch('staging', checkout: true)
@@ -116,6 +119,24 @@ module Pronto
             expect(run_output.count).to eql(2)
             expect(run_output[0].msg).to eql('E999 IndentationError')
             expect(run_output[1].msg).to eql('E113 unexpected indentation')
+          end
+
+          context 'when repository uses a custom format' do
+            before(:each) do
+              configuration = <<-HEREDOC
+                [flake8]
+                format = %(path)s:%(row)d: [%(code)s] %(text)s
+              HEREDOC
+
+              add_to_index('.flake8', configuration)
+
+              create_commit
+            end
+
+            it 'correctly parses errors' do
+              run_output = flake8.run
+              expect(run_output.count).to eql(2)
+            end
           end
         end
       end

--- a/spec/support/repository_helper.rb
+++ b/spec/support/repository_helper.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 module RepositoryHelper
   module_function
 


### PR DESCRIPTION
Hi,

First of all, thank you for this useful `gem`! I tried using it today on a project at work but encountered a crash similar to this:

```
Traceback (most recent call last):
        21: from /home/gedas/.rbenv/versions/2.5.0/bin/pronto:23:in `<main>'
        20: from /home/gedas/.rbenv/versions/2.5.0/bin/pronto:23:in `load'
        19: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/bin/pronto:6:in `<top (required)>'
        18: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
        17: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
        16: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
        15: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
        14: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/cli.rb:60:in `run'
        13: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/cli.rb:60:in `chdir'
        12: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/cli.rb:61:in `block in run'
        11: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto.rb:64:in `run'
        10: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/runners.rb:13:in `run'
         9: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/runners.rb:13:in `each'
         8: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-0.9.5/lib/pronto/runners.rb:20:in `block in run'
         7: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:56:in `run'
         6: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:63:in `run_flake8'
         5: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:63:in `chdir'
         4: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:67:in `block in run_flake8'
         3: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:81:in `parse_output'
         2: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:81:in `map'
         1: from /home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:81:in `block in parse_output'
/home/gedas/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/pronto-flake8-0.1.0/lib/pronto/flake8.rb:86:in `parse_output_line': undefined method `strip' for nil:NilClass (NoMethodError)
```

The problem was that our project is using a custom flake8 configuration which includes `format = pylint` option which does not print out the column in the error message. For reference: https://github.com/PyCQA/flake8/blob/9631dac52aa6ed8a3de9d0983c3c7b0267ae7d6d/src/flake8/formatting/default.py#L56

In other words, `splits` in [`parse_output_line`](https://github.com/scoremedia/pronto-flake8/blob/7c55f837af95b850b24f2297f2c64287f03f7f13/lib/pronto/flake8.rb#L84-L94) ends up being an array of 3 elements instead of 4, thus `message` is `nil` and we get a `NoMethodError`.

Here I provide a solution of overriding any custom flake8 format with the default using `--format=default`

I have also added `require 'tmpdir'` to `spec/support/repository_helper.rb` because I was getting the following error:

```
Failures:

  1) Pronto::Flake8#run patches are nil returns an empty array
     Failure/Error: @tmp_git_dir = Dir.mktmpdir

     NoMethodError:
       undefined method `mktmpdir' for Dir:Class
       Did you mean?  mkdir
     # ./spec/support/repository_helper.rb:7:in `create_repository'
     # ./spec/pronto/flake8_spec.rb:71:in `block (3 levels) in <module:Pronto>'
```