### PR TITLE
Relax pronto requirement

### DIFF
--- a/lib/pronto/flake8/version.rb
+++ b/lib/pronto/flake8/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module Flake8Version
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/lib/pronto/flake8/version.rb
+++ b/lib/pronto/flake8/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module Flake8Version
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end

--- a/pronto-flake8.gemspec
+++ b/pronto-flake8.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'flake8 (in PATH)'
 
-  s.add_dependency('pronto', '~> 0.9.5', '< 0.11.0')
+  s.add_dependency('pronto', '< 0.11.0')
   s.add_dependency('rugged', '~> 0.24', '>= 0.23.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')


### PR DESCRIPTION
I think the previous PR's attempt to relax the pronto requirement and allow 0.10.0 didn't actually work due to the inclusion of the `~> 0.9.5`.  This seems to resolve the issue.