### PR TITLE
Fix error when using config file

### DIFF
--- a/lib/pronto/flake8.rb
+++ b/lib/pronto/flake8.rb
@@ -47,7 +47,7 @@ module Pronto
 
       CONFIG_KEYS.each do |config_key|
         next unless config[config_key]
-        send("#{config_key}=", config[config_key])
+	instance_variable_set("@#{config_key}", config[config_key])
       end
     end
 


### PR DESCRIPTION
Fix for an error.
```
pronto-flake8/lib/pronto/flake8.rb:50:in `block in read_config': undefined method `flake8_executable=' for #<Pronto::Flake8:0x0000563f1b5e2d28> (NoMethodError)
```
due to this I could not use the config file with custom flake8 executable.
Ruby version 2.5.7